### PR TITLE
refacto: SplitTiles maps alternative tiles naming and removed SimpleTiles

### DIFF
--- a/kandora.bot/commands/MahjongCommands.cs
+++ b/kandora.bot/commands/MahjongCommands.cs
@@ -30,7 +30,7 @@ namespace kandora.bot.commands
         {
             try
             {
-                List<string> basicHand = HandParser.SimpleTiles(hand).Where(x => x.Length == 2).ToList();
+                List<string> basicHand = HandParser.SplitTiles(hand);
                 if (basicHand.Count == 0)
                 {
                     throw new Exception("invalid hand");

--- a/kandora.bot/commands/regular/MahjongCommands.cs
+++ b/kandora.bot/commands/regular/MahjongCommands.cs
@@ -27,7 +27,7 @@ namespace kandora.bot.commands.regular
         {
             try
             {
-                List<string> basicHand = HandParser.SimpleTiles(hand).Where(x => x.Length == 2).ToList();
+                List<string> basicHand = HandParser.SplitTiles(hand);
                 if (basicHand.Count == 0)
                 {
                     throw new Exception("invalid hand");

--- a/kandora.bot/commands/slash/MahjongSlashCommands.cs
+++ b/kandora.bot/commands/slash/MahjongSlashCommands.cs
@@ -23,7 +23,7 @@ namespace kandora.bot.commands.slash
             FileStream stream = null;
             try
             {
-                var basicHand = HandParser.SimpleTiles(handStr).Where(x => x.Length == 2).ToList();
+                var basicHand = HandParser.SplitTiles(handStr);
                 if (basicHand.Count == 0)
                 {
                     throw new Exception("invalid hand");

--- a/kandora.bot/utils/ImageToolbox.cs
+++ b/kandora.bot/utils/ImageToolbox.cs
@@ -46,7 +46,7 @@ namespace kandora.bot.utils
 
         public static FileStream GetImageFromTiles(string hand, bool separateLastTile=false)
         {
-            List<string> tiles = HandParser.SimpleTiles(hand).Where(x => x.Length == 2).ToList();
+            List<string> tiles = HandParser.SplitTiles(hand);
             var shouldSeparateLastTile = separateLastTile && tiles.Count == 14;
             var outputFilePath = string.Join(dirChar, new string[] { outputDirPath, GetFileName(hand, shouldSeparateLastTile) });
             if (!ImageExists(hand, shouldSeparateLastTile))

--- a/kandora.tests/HandParserTests/SimplifyTileTests.cs
+++ b/kandora.tests/HandParserTests/SimplifyTileTests.cs
@@ -1,0 +1,42 @@
+﻿using kandora.bot.utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace kandora.tests.HandParserTests;
+
+public class SimplifyTileTests
+{
+    [Theory]
+    [InlineData("1s", "1s")]
+    [InlineData("3p", "3p")]
+    [InlineData("5z", "5z")]
+    [InlineData("9e", "9e")]
+    [InlineData("iiiii", "iiiii")]
+    [InlineData("1z8p", "1z8p")]
+    [InlineData("test", "test")]
+    public void WhenSimpleValues_ShouldReturnTheSame(string entry, string expectedOutput)
+    {
+        string returnedValue = HandParser.SimplifyTile(entry);
+
+        Assert.Equal(expectedOutput, returnedValue);
+    }
+
+    [Theory]
+    [InlineData("Ew", "1z")]
+    [InlineData("Nw", "4z")]
+    [InlineData("1w", "1z")]
+    [InlineData("4w", "4z")]
+    [InlineData("Wd", "5z")]
+    [InlineData("Rd", "7z")]
+    [InlineData("1d", "5z")]
+    [InlineData("3d", "7z")]
+    public void WhenAlternateValues_ShouldReturnSimpleValues(string entry, string expectedOutput)
+    {
+        string returnedValue = HandParser.SimplifyTile(entry);
+
+        Assert.Equal(expectedOutput, returnedValue);
+    }
+}

--- a/kandora.tests/HandParserTests/SplitTilesTests.cs
+++ b/kandora.tests/HandParserTests/SplitTilesTests.cs
@@ -13,6 +13,8 @@ public class SplitTileTests
     [InlineData("123sp45z123s", "1s2s3s4z5z")]
     [InlineData("123s123k", "1s2s3s")]
     [InlineData("123k", "")]
+    [InlineData("123d222w154sEEEw", "5z6z7z2z1s5s4s1z")]
+    [InlineData("RRRd", "7z")]
     public void WhenMethodUsedWithUnique_ShouldReturnHandParsed(string hand, string expectedOutput)
     {
         List<string> tiles = HandParser.SplitTiles(hand, true);
@@ -38,6 +40,9 @@ public class SplitTileTests
     [InlineData("123sp45z123s", "1s2s3s4z5z1s2s3s")]
     [InlineData("123s123k", "1s2s3s")]
     [InlineData("123k", "")]
+    [InlineData("123s", "1s2s3s")]
+    [InlineData("123d222w154sEEEw", "5z6z7z2z2z2z1s5s4s1z1z1z")]
+    [InlineData("RRRd", "7z7z7z")]
     public void WhenMethodUsedWithoutUnique_ShouldReturnHandParsed(string hand, string expectedOutput)
     {
         List<string> tiles = HandParser.SplitTiles(hand, false);


### PR DESCRIPTION
SplitTiles(hand, false) makes the same thing than SimpleTiles() now